### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -113,7 +113,9 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        if parsed_url.hostname and parsed_url.hostname.endswith(".modac.cancer.gov"):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Gene-Expression-Autoencoder/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Gene-Expression-Autoencoder/security/code-scanning/1)

To fix the issue, we need to ensure that the `origin` variable is parsed as a URL and its hostname is explicitly checked against the expected domain. This can be achieved using Python's `urllib.parse` module to extract the hostname and then performing a proper comparison. Specifically, we should check if the hostname ends with `.modac.cancer.gov` to allow for subdomains while preventing malicious URLs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
